### PR TITLE
Support 'pass' service and extended service names

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ the resource name.
     command => 'smtp',
   }
 
-  postconf { 'foo:mytransport/unix':
+  postconf_master { 'foo:mytransport/unix':
     service    => 'mytransport',
     type       => 'unix',
     config_dir => '/etc/postfix-foo',

--- a/lib/puppet/provider/postconf_master/postconf.rb
+++ b/lib/puppet/provider/postconf_master/postconf.rb
@@ -151,7 +151,7 @@ Puppet::Type.type(:postconf_master).provide(:postconf) do
 
     pc_output = postconf_cmd(*opts).encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
 
-    pc_output.scan(%r{^(\w+)\/(\w+)\/(\w+) = (.*)$}).
+    pc_output.scan(%r{^(\S+)\/(\w+)\/(\w+) = (.*)$}).
       each_with_object({}) do |larray, hash|
         hash["#{larray[0]}/#{larray[1]}"] ||= {}
         hash["#{larray[0]}/#{larray[1]}"][larray[2]] = larray[3]


### PR DESCRIPTION
Services in master.cf can be of different types, one of them being
'pass', which was not supported. Furthermore, different types have
different name formats. The 'inet' type allows host:port to be
specified in various formats, while all other types allow a
path/to/a/socket as the name.
This change relaxes the validation and matching patterns to allow such
extended names.
NOTE: With inet service names being able to contain semicolons, the
config_dir must now always be specified explicitly (because any prefix
will be matched to the service property)